### PR TITLE
相談デスクへのリンクをOshidori化して作成

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -7,10 +7,19 @@ title: Welcome to Middleman
 .os1-content
   %h1.os1-title.-h1 テストです
 
+.counseling-desk-information
+  %h2.os1-title.-h3 迷ったら結婚式のプロに相談しよう
+  %p.counseling-desk-information__text 結婚式を知り尽くしたプロのアドバイザーが、お悩みやご要望に応じてピッタリの式場をご紹介
+  %img.counseling-desk-information__image{ src: "https://d4w9i1j5cm7ll.cloudfront.net/o/C001/smartphone/desk/top/desk_thumbnail_710_240.jpg", alt: "みんなのウェディング相談デスク" }
+  .os1-primary-button.-size-L.counseling-desk-information__button
+    %button.os1-primary-button__item{:type => "button"}
+      %span.os1-primary-button__text LINEで相談する
+  %a.os1-link-see-more みんなのウェディング相談デスクへ
+
 %footer.os1-form-footer
-    %a.os1-form-footer__link{ href: "#" } 会社概要
-    |
-    %a.os1-form-footer__link{ href: "#" } 会員規約
-    |
-    %a.os1-form-footer__link{ href: "#" } プライバシーポリシー
+  %a.os1-form-footer__link{ href: "#" } 会社概要
+  |
+  %a.os1-form-footer__link{ href: "#" } 会員規約
+  |
+  %a.os1-form-footer__link{ href: "#" } プライバシーポリシー
   %p.os1-form-footer__copyright &copy; Minnano Wedding Co., Ltd.

--- a/source/stylesheets/_counseling-desk-information.scss
+++ b/source/stylesheets/_counseling-desk-information.scss
@@ -4,8 +4,8 @@
 
   .counseling-desk-information__text {
     @include os1-font-size($font-size: S);
-    color: $os1-color-navy-D;
     @include os1-set-margin($margin-side: top);
+    color: $os1-color-navy-D;
   }
 
   .counseling-desk-information__image {

--- a/source/stylesheets/_counseling-desk-information.scss
+++ b/source/stylesheets/_counseling-desk-information.scss
@@ -1,0 +1,19 @@
+.counseling-desk-information {
+  @include os1-default-border($border-side: top);
+  padding: 0 10px;
+
+  .counseling-desk-information__text {
+    @include os1-font-size($font-size: S);
+    color: $os1-color-navy-D;
+    @include os1-set-margin($margin-side: top);
+  }
+
+  .counseling-desk-information__image {
+    width: 100%;
+    @include os1-set-margin($margin-side: top);
+  }
+
+  .counseling-desk-information__button {
+    @include os1-set-margin($margin-side: top);
+  }
+}

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1,3 +1,5 @@
 @import "reset";
 @import "oshidori/common/all.scss";
-@import "header"
+@import "header";
+
+@import "counseling-desk-information";


### PR DESCRIPTION
## 目的
相談デスクへのリンクの追加

本番環境では共通コンポーネントのスタイル等を使い回すと思いますが、ひとまず設置出来る状態にしたかったので敢えてOshidori化して作成しました。


## 内容
- [x] `_counseling-desk-information.scss`の作成
- [x] `index.html.haml`と`site.css.scss`への当該部の追記

## 懸念
* `index.html.haml`にて`.os1-primary-button.-size-L.counseling-desk-information__button`というクラス指定をしていますが、「こうするべき」等あれば指摘をお願いします。
* （本筋ではないが）Oshidori化しない状態にしたほうが良さそうであれば変更します。