### PR TITLE
タスクの進捗バーのサイズ指定方法を%に変更

### DIFF
--- a/source/stylesheets/task-card.scss
+++ b/source/stylesheets/task-card.scss
@@ -18,6 +18,7 @@
 
   .task-card__infomation {
     box-sizing: border-box;
+    width: 75%;
   }
 
   .task-card__name {
@@ -35,7 +36,7 @@
     @include os1-set-margin($margin-side: top, $margin-size: S);
     box-sizing: border-box;
     height: 25px;
-    width: 256px;
+    width: 100%;
     border-radius: 12px;
     border: solid 1px $os1-color-gold-3S;
     border-top: solid 2px $os1-color-gold-3S;
@@ -50,11 +51,11 @@
 
     &.-percent100 {
       background-color: #FF9E2B;
-      width: 250px;
+      width: calc(100% - 4px);
       &::after {
         content: "完了";
         display: inline-block;
-        width: 250px;
+        width: calc(100% - 4px);
         color: #ffffff;
         font-weight: bold;
         text-align: center;
@@ -64,12 +65,12 @@
 
     &.-percent60 {
       background-color: #FFBB4A;
-      width: 150px;
+      width: calc(60% - 4px);
     }
 
     &.-percent30 {
       background-color: #FFD971;
-      width: 75px;
+      width: calc(30% - 4px);
     }
 
     &.-percent0 {

--- a/source/stylesheets/task-filter.scss
+++ b/source/stylesheets/task-filter.scss
@@ -38,9 +38,12 @@
     @include os1-set-margin($margin-side: bottom, $margin-size: S);
     @include os1-font-size($font-size: M);
     display: inline-block;
-    text-align: center;
     width: 100%;
+    text-align: center;
     box-sizing: border-box;
+  }
+
+  .task-filter__reset-link{
     color: $os1-color-navy;
   }
 }

--- a/source/tasklist.html.haml
+++ b/source/tasklist.html.haml
@@ -30,7 +30,8 @@ title: 結婚式準備やること一覧
             %input.os1-default-checkbox__input{ type: "checkbox" , name: "foo" , value: "foo1" }
             %span.os1-default-checkbox__text 未完了のみ表示する
 
-        %a.task-filter__reset.-hidden{ href: "#" } 表示をリセットする
+        .task-filter__reset.-hidden
+          %a.task-filter__reset-link{ href: "#" } 表示をリセットする
 
     .tasklist
       %h4.os1-title.-h4 12ヶ月前〜9ヶ月前からはじめよう


### PR DESCRIPTION
## 【目的】
* タスク進捗バーのスタイルを他のページでも使えるようにする
* サイズが小さい端末でも綺麗に表示できるようにする

## 【内容】
- [x] task-card.scss内、task-card__progress-flameとtask-card__progress-barのwidthを変更
- [x] トップのフィルターの「表示をリセットする」が空白までクリックできていたのでtasklist.html.hamlとtask-filter.scssを修正