### PR TITLE
タスク一覧のプログレスバーをelementからblockにする

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -21,3 +21,4 @@
 @import "task-filter.scss";
 @import "tasklist-container.scss";
 @import "task-card";
+@import "task-progress";

--- a/source/stylesheets/task-card.scss
+++ b/source/stylesheets/task-card.scss
@@ -31,59 +31,7 @@
       color: $os1-color-navy-1S;
     }
   }
-
-  .task-card__progress-frame {
-    @include os1-set-margin($margin-side: top, $margin-size: S);
-    box-sizing: border-box;
-    height: 25px;
-    width: 100%;
-    border-radius: 12px;
-    border: solid 1px $os1-color-gold-3S;
-    border-top: solid 2px $os1-color-gold-3S;
-  }
-
-  .task-card__progress-bar {
-    box-sizing: border-box;
-    height: 18px;
-    border-radius: 9px;
-    margin-top: 2px;
-    margin-left: 2px;
-
-    &.-percent100 {
-      background-color: #FF9E2B;
-      width: calc(100% - 4px);
-      &::after {
-        content: "完了";
-        display: inline-block;
-        width: calc(100% - 4px);
-        color: #ffffff;
-        font-weight: bold;
-        text-align: center;
-        line-height: 18px;
-      }
-    }
-
-    &.-percent60 {
-      background-color: #FFBB4A;
-      width: calc(60% - 4px);
-    }
-
-    &.-percent30 {
-      background-color: #FFD971;
-      width: calc(30% - 4px);
-    }
-
-    &.-percent0 {
-      &::after {
-        content: "0%";
-        display: inline-block;
-        line-height: 18px;
-        margin-left: 10px;
-        color: $os1-color-navy-2S;
-      }
-    }
-  }
-
+  
   .task-card__arrow {
     box-sizing: border-box;
     font-size: 20px;

--- a/source/stylesheets/task-progress.scss
+++ b/source/stylesheets/task-progress.scss
@@ -1,5 +1,5 @@
 .task-progress {
-  .task-progress-frame {
+  .task-progress__frame {
     @include os1-set-margin($margin-side: top, $margin-size: S);
     box-sizing: border-box;
     height: 25px;
@@ -9,7 +9,7 @@
     border-top: solid 2px $os1-color-gold-3S;
   }
 
-  .task-progress-bar {
+  .task-progress__bar {
     box-sizing: border-box;
     height: 18px;
     border-radius: 9px;

--- a/source/stylesheets/task-progress.scss
+++ b/source/stylesheets/task-progress.scss
@@ -1,0 +1,53 @@
+.task-progress {
+  .task-progress-frame {
+    @include os1-set-margin($margin-side: top, $margin-size: S);
+    box-sizing: border-box;
+    height: 25px;
+    width: 100%;
+    border-radius: 12px;
+    border: solid 1px $os1-color-gold-3S;
+    border-top: solid 2px $os1-color-gold-3S;
+  }
+
+  .task-progress-bar {
+    box-sizing: border-box;
+    height: 18px;
+    border-radius: 9px;
+    margin-top: 2px;
+    margin-left: 2px;
+
+    &.-percent100 {
+      background-color: #FF9E2B;
+      width: calc(100% - 4px);
+      &::after {
+        content: "完了";
+        display: inline-block;
+        width: calc(100% - 4px);
+        color: #ffffff;
+        font-weight: bold;
+        text-align: center;
+        line-height: 18px;
+      }
+    }
+
+    &.-percent60 {
+      background-color: #FFBB4A;
+      width: calc(60% - 4px);
+    }
+
+    &.-percent30 {
+      background-color: #FFD971;
+      width: calc(30% - 4px);
+    }
+
+    &.-percent0 {
+      &::after {
+        content: "0%";
+        display: inline-block;
+        line-height: 18px;
+        margin-left: 10px;
+        color: $os1-color-navy-2S;
+      }
+    }
+  }
+}

--- a/source/tasklist.html.haml
+++ b/source/tasklist.html.haml
@@ -30,7 +30,7 @@ title: 結婚式準備やること一覧
             %input.os1-default-checkbox__input{ type: "checkbox" , name: "foo" , value: "foo1" }
             %span.os1-default-checkbox__text 未完了のみ表示する
 
-        .task-filter__reset.-hidden
+        .task-filter__reset
           %a.task-filter__reset-link{ href: "#" } 表示をリセットする
 
     .tasklist
@@ -277,7 +277,7 @@ title: 結婚式準備やること一覧
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name お礼を渡す
-          .task-progress
+          .task-progresnks
             .task-progress-frame
               .task-progress-bar
         .task-card__arrow

--- a/source/tasklist.html.haml
+++ b/source/tasklist.html.haml
@@ -39,8 +39,8 @@ title: 結婚式準備やること一覧
         .task-card__infomation
           .task-card__name.-completed 式場を決める
           .task-progress
-            .task-progress-frame
-              .task-progress-bar.-percent100
+            .task-progress__frame
+              .task-progress__bar.-percent100
         .task-card__arrow
           %span.os1-symbol-arrow-right
 
@@ -50,64 +50,64 @@ title: 結婚式準備やること一覧
         .task-card__infomation
           .task-card__name.-completed ゲストの出欠確認
           .task-progress
-            .task-progress-frame
-              .task-progress-bar.-percent100
+            .task-progress__frame
+              .task-progress__bar.-percent100
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 指輪の準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar.-percent60
+            .task-progress__frame
+              .task-progress__bar.-percent60
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name ウェディングアイテムの準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar.-percent30
+            .task-progress__frame
+              .task-progress__bar.-percent30
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 前撮り
           .task-progress
-            .task-progress-frame
-              .task-progress-bar.-percent0
+            .task-progress__frame
+              .task-progress__bar.-percent0
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 衣装の準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name コンセプトを決める
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 親への挨拶
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 二次会を決める
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
 
@@ -117,40 +117,40 @@ title: 結婚式準備やること一覧
         .task-card__infomation
           .task-card__name ブーケの準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 挨拶・受付・余興の準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 引き出物の準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 当日のイベントを決める
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 装花の準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
 
@@ -160,32 +160,32 @@ title: 結婚式準備やること一覧
         .task-card__infomation
           .task-card__name BGMを決める
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name ウェディングケーキの準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name ゲスト当日対応準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 料理・ドリンクを決める
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
 
@@ -195,40 +195,40 @@ title: 結婚式準備やること一覧
         .task-card__infomation
           .task-card__name ブーケの準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 挨拶・受付・余興の準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 引き出物の準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 当日のイベントを決める
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 装花の準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
 
@@ -238,48 +238,48 @@ title: 結婚式準備やること一覧
         .task-card__infomation
           .task-card__name スピーチの準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 自分を磨く
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 式場とのやりとり
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 親への手紙の準備
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 搬入
           .task-progress
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name お礼を渡す
           .task-progresnks
-            .task-progress-frame
-              .task-progress-bar
+            .task-progress__frame
+              .task-progress__bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
 

--- a/source/tasklist.html.haml
+++ b/source/tasklist.html.haml
@@ -38,9 +38,9 @@ title: 結婚式準備やること一覧
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name.-completed 式場を決める
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar.-percent100
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar.-percent100
         .task-card__arrow
           %span.os1-symbol-arrow-right
 
@@ -49,65 +49,65 @@ title: 結婚式準備やること一覧
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name.-completed ゲストの出欠確認
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar.-percent100
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar.-percent100
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 指輪の準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar.-percent60
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar.-percent60
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name ウェディングアイテムの準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar.-percent30
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar.-percent30
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 前撮り
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar.-percent0
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar.-percent0
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 衣装の準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name コンセプトを決める
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 親への挨拶
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 二次会を決める
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
 
@@ -116,41 +116,41 @@ title: 結婚式準備やること一覧
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name ブーケの準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 挨拶・受付・余興の準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 引き出物の準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 当日のイベントを決める
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 装花の準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
 
@@ -159,33 +159,33 @@ title: 結婚式準備やること一覧
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name BGMを決める
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name ウェディングケーキの準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name ゲスト当日対応準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 料理・ドリンクを決める
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
 
@@ -194,41 +194,41 @@ title: 結婚式準備やること一覧
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name ブーケの準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 挨拶・受付・余興の準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 引き出物の準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 当日のイベントを決める
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 装花の準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
 
@@ -237,49 +237,49 @@ title: 結婚式準備やること一覧
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name スピーチの準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 自分を磨く
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 式場とのやりとり
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 親への手紙の準備
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name 搬入
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name お礼を渡す
-          .task-card__progress
-            .task-card__progress-frame
-              .task-card__progress-bar
+          .task-progress
+            .task-progress-frame
+              .task-progress-bar
         .task-card__arrow
           %span.os1-symbol-arrow-right
 


### PR DESCRIPTION
【目的】
- プログレスバーを使い回せるようにする

【内容】
- task-card内のelementだったプログレスバーを、task-progressというblockに変更する
- task-progress.scssを作り、task-card.scss内のプログレスバーのスタイル指定を移動する