### PR TITLE
tasklist.html.haml派生ページの細かい修正

### DIFF
--- a/source/first-access__tasklist.html.haml
+++ b/source/first-access__tasklist.html.haml
@@ -285,7 +285,7 @@ title: 結婚式準備やること一覧 / ふたりのToDoリスト
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name お礼を渡す
-          .task-progresnks
+          .task-progress
             .task-progress__frame
               .task-progress__bar
         .task-card__arrow

--- a/source/first-access__tasklist.html.haml
+++ b/source/first-access__tasklist.html.haml
@@ -30,9 +30,6 @@ title: 結婚式準備やること一覧 / ふたりのToDoリスト
             %input.os1-default-checkbox__input{ type: "checkbox" , name: "foo" , value: "foo1" }
             %span.os1-default-checkbox__text 未完了のみ表示する
 
-        .task-filter__reset
-          %a.task-filter__reset-link{ href: "#" } 表示をリセットする
-
     .tasklist
       %h4.os1-title.-h4 12ヶ月前〜9ヶ月前からはじめよう
       %a.task-card{ href: "task__tutorial-30.html" }

--- a/source/normal-2__tasklist.html.haml
+++ b/source/normal-2__tasklist.html.haml
@@ -284,7 +284,7 @@ title: 結婚式準備やること一覧 / ふたりのToDoリスト
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name お礼を渡す
-          .task-progresnks
+          .task-progress
             .task-progress__frame
               .task-progress__bar
         .task-card__arrow

--- a/source/normal-2__tasklist.html.haml
+++ b/source/normal-2__tasklist.html.haml
@@ -30,9 +30,6 @@ title: 結婚式準備やること一覧 / ふたりのToDoリスト
             %input.os1-default-checkbox__input{ type: "checkbox" , name: "foo" , value: "foo1" }
             %span.os1-default-checkbox__text 未完了のみ表示する
 
-        .task-filter__reset
-          %a.task-filter__reset-link{ href: "#" } 表示をリセットする
-
     .tasklist
       %h4.os1-title.-h4 12ヶ月前〜9ヶ月前からはじめよう
       %a.task-card{ href: "task__tutorial-100.html" }

--- a/source/tasklist.html.haml
+++ b/source/tasklist.html.haml
@@ -277,7 +277,7 @@ title: 結婚式準備やること一覧
       %a.task-card{ href: "#" }
         .task-card__infomation
           .task-card__name お礼を渡す
-          .task-progresnks
+          .task-progress
             .task-progress__frame
               .task-progress__bar
         .task-card__arrow


### PR DESCRIPTION
## 目的
細かい修正を行う

## 内容

- [x] tasklist.html.haml派生のページで、最後のやることの表示がおかしくなっていたのを修正

修正前|修正後
---|---
<img width="250" alt="スクリーンショット 2019-07-31 11 12 34" src="https://user-images.githubusercontent.com/50356894/62178511-51be6d00-b384-11e9-9174-735b13482ce6.png">|<img width="250" alt="スクリーンショット 2019-07-31 11 12 46" src="https://user-images.githubusercontent.com/50356894/62178513-53883080-b384-11e9-9356-04364454d88f.png">

- [x] first-access__tasklist.html.hamlとnormal-2__tasklist.html.hamlから「表示をリセットする」を削除(絞り込み前の画面なので)
