### PR TITLE
やることカードの縦幅を可変にする

### DIFF
--- a/source/normal-1__tasklist.html.haml
+++ b/source/normal-1__tasklist.html.haml
@@ -31,7 +31,6 @@ title: 結婚式準備やること一覧 / ふたりのToDoリスト
             %input.os1-default-checkbox__input{ type: "checkbox" , name: "foo" , value: "foo1" }
             %span.os1-default-checkbox__text
               %a.task-filter__reset-container{ href: "normal-1__tasklist-only-incomplete.html" } 未完了のみ表示する
-              -# 色を変えるぞ色を
 
     .tasklist
       %h4.os1-title.-h4 12ヶ月前〜9ヶ月前からはじめよう

--- a/source/stylesheets/_task-card.scss
+++ b/source/stylesheets/_task-card.scss
@@ -1,7 +1,7 @@
 .task-card {
   @include os1-set-margin($margin-side: bottom, $margin-size: S);
   box-sizing: border-box;
-  height: height;
+  height: auto;
   width: 100%;
   padding: 15px 10px;
   border: solid 1px $os1-color-gold-2S;

--- a/source/stylesheets/_task-card.scss
+++ b/source/stylesheets/_task-card.scss
@@ -1,9 +1,9 @@
 .task-card {
-  @include os1-set-padding($padding-side: left-right, $padding-size: S);
   @include os1-set-margin($margin-side: bottom, $margin-size: S);
   box-sizing: border-box;
-  height: 91px;
+  height: height;
   width: 100%;
+  padding: 15px 10px;
   border: solid 1px $os1-color-gold-2S;
   border-bottom: solid 2px $os1-color-gold-2S;
   border-radius: 4px;
@@ -31,7 +31,7 @@
       color: $os1-color-navy-1S;
     }
   }
-  
+
   .task-card__arrow {
     box-sizing: border-box;
     font-size: 20px;


### PR DESCRIPTION
## 目的
端末によってキツキツになるので、やることカードの縦幅をautoにする

## 内容

- [x] task-card.scssで、`.task-card`のheightを決め打ちの数字からautoに変更
<img width="407" alt="スクリーンショット 2019-07-31 12 05 14" src="https://user-images.githubusercontent.com/50356894/62180573-79650380-b38b-11e9-878a-36dc15040686.png">
