### PR TITLE
閲覧済みタスクへのリンクカードにおけるborder-colorが紫になる問題を修正

### DIFF
--- a/source/stylesheets/_task-card.scss
+++ b/source/stylesheets/_task-card.scss
@@ -12,6 +12,12 @@
   align-items: center;
   text-decoration: none;
 
+  &:visited {
+    * {
+      all: initial;
+    }
+  }
+
   &:last-child {
     @include os1-set-margin($margin-side: bottom, $margin-size: XL);
   }


### PR DESCRIPTION
## 目的
本来$os1-color-gold-3Sを指定しているborderがvisited環境下に置いて紫色になるバグを修正する。

## 内容
- [x] `.task-card:visited`に`*{ all: initial; }`を追加

### 根拠
.task-card:visited内の.task-progressにcssを当てたかったが、
```css
.task-card:visited {
  .task-progress__frame {
    border-color: $os1-color-gold-3S;
  }
}
```
これではBEMが破綻するため、敢えて`*`の`all`にCSSを当てました。

指定としては、**`task-card`というBlockはvisitedかどうかに関わらず同じ表示を行う**という指定です。
